### PR TITLE
Bugfix/51 corrigir criacao de usuarios

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_01_191434) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_06_140616) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,10 +9,10 @@ if Rails.env.development?
   company_2 = Company.create(cnpj: FFaker::IdentificationBR.cnpj)
 
   # Users
-  UserCreator.create_user('Administrador 1', 'admin1@limpar.com', :admin, company_1, 'avatar-1.jpg')
+  UserCreator.create_user('Administrador 1', 'admin1@limpar.com', :admin, company_1, avatar_file: 'avatar-2.jpg')
   UserCreator.create_user('Administrador 1', 'admin2@limpar.com', :admin, company_2)
-  UserCreator.create_user('Funcionário 1', 'employee1@limpar.com', :employee, company_1, 'avatar-2.jpg')
-  UserCreator.create_user('Funcionário 2', 'employee2@limpar.com', :technical_lead, company_1, 'avatar-2.jpg')
+  UserCreator.create_user('Funcionário 1', 'employee1@limpar.com', :employee, company_1, avatar_file: 'avatar-2.jpg')
+  UserCreator.create_user('Funcionário 2', 'employee2@limpar.com', :technical_lead, company_1, avatar_file: 'avatar-2.jpg', cft: FFaker::Lorem.characters(10))
 
   # Clients
   10.times do |i|

--- a/lib/seed/user_creator.rb
+++ b/lib/seed/user_creator.rb
@@ -1,6 +1,6 @@
 module UserCreator
-  def self.create_user(name, email, role, company, avatar_file = nil)
-    user = User.create!(
+  def self.create_user(name, email, role, company, options = {})
+    user_params = {
       name: name,
       email: email,
       password: '000000',
@@ -8,16 +8,21 @@ module UserCreator
       role: role,
       confirmed_at: DateTime.now,
       company: company
-    )
+    }
+    user_params[:cft] = options[:cft] if options[:cft].present?
 
-    if avatar_file
-      user.avatar.attach(
-        io: File.open(Rails.root.join('spec', 'support', 'images', avatar_file)),
-        filename: avatar_file,
-        content_type: 'image/jpg'
-      )
-    end
+    user = User.create!(user_params)
+
+    attach_avatar(user, options[:avatar_file]) if options[:avatar_file]
 
     user
+  end
+
+  def self.attach_avatar(user, avatar_file)
+    user.avatar.attach(
+      io: File.open(Rails.root.join('spec', 'support', 'images', avatar_file)),
+      filename: avatar_file,
+      content_type: 'image/jpg'
+    )
   end
 end

--- a/spec/models/cooler_spec.rb
+++ b/spec/models/cooler_spec.rb
@@ -1,12 +1,21 @@
 # == Schema Information
 #
-# Table name: cooler
+# Table name: coolers
 #
 #  id         :bigint           not null, primary key
 #  tag        :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  client_id  :integer
 #  company_id :integer
+#
+# Indexes
+#
+#  index_coolers_on_client_id  (client_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (client_id => clients.id)
 #
 require 'rails_helper'
 


### PR DESCRIPTION
@marcodotcastro, @PhilipeeX,

Como o codigo já não possuía testes, não criei novos para adiantar o trabalho, mas caso necessário estou à disposição.

A solução que pensei deixa os campos opcionais, avatar e cft(que só é necessário para esta regra) como um hash **"options"**. Como o rubocop acusou problema de excesso de atributos para um método tive que utilizar essa forma para adicionar o valor do cft, assim deixando o código mais enxuto e conciso.